### PR TITLE
FailedTileLoopException becomes a checked exception.

### DIFF
--- a/src/main/java/ome/io/nio/Utils.java
+++ b/src/main/java/ome/io/nio/Utils.java
@@ -103,10 +103,9 @@ public class Utils
 
     /**
      * The processing of a tile failed so abort the loop.
-     * <strong>Warning:</strong> Will become a checked exception after OMERO 5.4.x.
      */
     @SuppressWarnings("serial")
-    public static class FailedTileLoopException extends RuntimeException {
+    public static class FailedTileLoopException extends Exception {
 
         private Integer tileCount = null;
 


### PR DESCRIPTION
This PR stops calling code from being able to ignore `FailedTileLoopException`. This change is best made in a major release.