### PR TITLE
javadoc

### DIFF
--- a/src/main/java/ome/io/nio/PixelBuffer.java
+++ b/src/main/java/ome/io/nio/PixelBuffer.java
@@ -569,7 +569,7 @@ public interface PixelBuffer extends Closeable
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
      * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * {@code buffer.length > {@link #getStackSize()()}}.
+     * {@code buffer.length > {@link #getStackSize()}}.
      */
     public void setStack(byte[] buffer, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException,

--- a/src/main/java/ome/io/nio/PixelBuffer.java
+++ b/src/main/java/ome/io/nio/PixelBuffer.java
@@ -1,6 +1,4 @@
 /*
- * ome.io.nio.PixelBuffer
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -479,7 +477,7 @@ public interface PixelBuffer extends Closeable
      * @param offset offset within the pixel buffer.
      * @param buffer a byte array of the data.
      * @throws IOException if there is a problem writing to the pixel buffer.
-     * @throws BufferOverflowException if <code>buffer.length > size</code>.
+     * @throws BufferOverflowException if {@code buffer.length > size}.
      */
     public void setRegion(Integer size, Long offset, byte[] buffer)
             throws IOException, BufferOverflowException;
@@ -490,7 +488,7 @@ public interface PixelBuffer extends Closeable
      * @param offset offset within the pixel buffer.
      * @param buffer a byte buffer of the data.
      * @throws IOException if there is a problem writing to the pixel buffer.
-     * @throws BufferOverflowException if <code>buffer.length > size</code>.
+     * @throws BufferOverflowException if {@code buffer.length > size}.
      */
     public void setRegion(Integer size, Long offset, ByteBuffer buffer)
             throws IOException, BufferOverflowException;
@@ -506,7 +504,7 @@ public interface PixelBuffer extends Closeable
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
      * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link #getRowSize()}</code>.
+     * {@code buffer.length > {@link #getRowSize()}}.
      */
     public void setRow(ByteBuffer buffer, Integer y, Integer z, Integer c,
             Integer t) throws IOException, DimensionsOutOfBoundsException,
@@ -522,7 +520,7 @@ public interface PixelBuffer extends Closeable
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
      * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link #getPlaneSize()}</code>.
+     * {@code buffer.length > {@link #getPlaneSize()}}.
      */
     public void setPlane(ByteBuffer buffer, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException,
@@ -538,7 +536,7 @@ public interface PixelBuffer extends Closeable
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
      * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link #getPlaneSize()}</code>.
+     * {@code buffer.length > {@link #getPlaneSize()}}.
      */
     public void setPlane(byte[] buffer, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException,
@@ -554,7 +552,7 @@ public interface PixelBuffer extends Closeable
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
      * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link #getStackSize()}</code>.
+     * {@code buffer.length > {@link #getStackSize()}}.
      */
     public void setStack(ByteBuffer buffer, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException,
@@ -571,7 +569,7 @@ public interface PixelBuffer extends Closeable
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
      * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link #getStackSize()()}</code>.
+     * {@code buffer.length > {@link #getStackSize()()}}.
      */
     public void setStack(byte[] buffer, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException,
@@ -586,7 +584,7 @@ public interface PixelBuffer extends Closeable
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
      * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link #getTimepointSize()}</code>.
+     * {@code buffer.length > {@link #getTimepointSize()}}.
      */
     public void setTimepoint(ByteBuffer buffer, Integer t) throws IOException,
             DimensionsOutOfBoundsException, BufferOverflowException;
@@ -600,7 +598,7 @@ public interface PixelBuffer extends Closeable
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
      * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link #getTimepointSize()}</code>.
+     * {@code buffer.length > {@link #getTimepointSize()}}.
      */
     public void setTimepoint(byte[] buffer, Integer t) throws IOException,
             DimensionsOutOfBoundsException, BufferOverflowException;

--- a/src/main/java/ome/io/nio/TileLoopIteration.java
+++ b/src/main/java/ome/io/nio/TileLoopIteration.java
@@ -1,6 +1,4 @@
 /*
- * ome.io.nio.TileLoopIteration
- *
  *   Copyright 2011-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -11,7 +9,7 @@ import ome.io.nio.Utils.FailedTileLoopException;
 
 /**
  * A single iteration of a tile for each loop.
- * @author Chris Allan <callan at blackcat dot ca>
+ * @author Chris Allan callan at blackcat dot ca
  * @since OMERO Beta-4.3.0
  */
 public interface TileLoopIteration
@@ -27,9 +25,9 @@ public interface TileLoopIteration
      * timepoint counters.
      * @param tileWidth Width of the tile requested. The tile request
      * itself may be smaller than the original tile width requested if
-     * <code>x + tileWidth > sizeX</code>.
+     * {@code x + tileWidth > sizeX}.
      * @param tileHeight Height of the tile requested. The tile request
-     * itself may be smaller if <code>y + tileHeight > sizeY</code>.
+     * itself may be smaller if {@code y + tileHeight > sizeY}.
      * @param tileCount Counter of the tile since the beginning of the loop.
      * @throws FailedTileLoopException if the loop should be aborted with no more tiles processed
      */

--- a/src/main/java/ome/io/nio/Utils.java
+++ b/src/main/java/ome/io/nio/Utils.java
@@ -1,6 +1,4 @@
 /*
- * ome.io.nio.Utils
- *
  *   Copyright 2011-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -9,7 +7,7 @@ package ome.io.nio;
 
 /**
  * General utility methods for working with ROMIO classes.
- * @author Chris Allan <callan at blackcat dot ca>
+ * @author Chris Allan callan at blackcat dot ca
  * @since OMERO Beta-4.3.0
  */
 public class Utils
@@ -21,9 +19,9 @@ public class Utils
      * @param pixelBuffer Pixel buffer which is backing the pixel data.
      * @param tileWidth <b>Maximum</b> width of the tile requested. The tile
      * request itself will be smaller than the original tile width requested if
-     * <code>x + tileWidth > sizeX</code>.
+     * {@code x + tileWidth > sizeX}.
      * @param tileHeight <b>Maximum</b> height of the tile requested. The tile
-     * request itself will be smaller if <code>y + tileHeight > sizeY</code>.
+     * request itself will be smaller if {@code y + tileHeight > sizeY}.
      * @throws FailedTileLoopException if the tile loop was aborted; exception bears completed tile count
      * @return The total number of tiles iterated over.
      */
@@ -47,9 +45,9 @@ public class Utils
      * @param iteration Invoker to call for each tile.
      * @param tileWidth <b>Maximum</b> width of the tile requested. The tile
      * request itself will be smaller than the original tile width requested if
-     * <code>x + tileWidth > sizeX</code>.
+     * {@code x + tileWidth > sizeX}.
      * @param tileHeight <b>Maximum</b> height of the tile requested. The tile
-     * request itself will be smaller if <code>y + tileHeight > sizeY</code>.
+     * request itself will be smaller if {@code y + tileHeight > sizeY}.
      * @return The total number of tiles iterated over.
      * @throws FailedTileLoopException if the tile loop was aborted; exception bears completed tile count
      */


### PR DESCRIPTION
fix javadoc warnings
In order to see if some warnings remain, you will need to use Java version > 1.8 (tested with Java 11)
Currently no warnings are returned if Java 1.8 is used
To check run ``gradle javadoc``