### PR TITLE
PixelsPyramidReader: Set canSeperateSeries for BF 6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testImplementation("junit:junit:4.12")
     testImplementation("org.testng:testng:6.14.2")
 
-    api("org.openmicroscopy:omero-common:5.5.0-m7")
+    api("org.openmicroscopy:omero-common:5.5.0-m8")
 
     // Keep from being exposed to child projects
     implementation("commons-io:commons-io:2.6")

--- a/src/main/java/ome/io/bioformats/OmeroPixelsPyramidReader.java
+++ b/src/main/java/ome/io/bioformats/OmeroPixelsPyramidReader.java
@@ -85,8 +85,8 @@ public class OmeroPixelsPyramidReader extends MinimalTiffReader {
     public void setId(String id) throws FormatException, IOException
     {
         log.debug("setId(" + id + ")");
-        super.setId(id);
         canSeparateSeries = false;
+        super.setId(id);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/ome/io/bioformats/OmeroPixelsPyramidReader.java
+++ b/src/main/java/ome/io/bioformats/OmeroPixelsPyramidReader.java
@@ -86,6 +86,7 @@ public class OmeroPixelsPyramidReader extends MinimalTiffReader {
     {
         log.debug("setId(" + id + ")");
         super.setId(id);
+        canSeparateSeries = false;
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
This PR should only be included alongside the upgrade to Bio-Formats 6.
It is setting a flag which was introduced as part of changes to MinimalTiffReader in BF 6.0.0
Derived formats such as this reader were affected and updated, see https://github.com/openmicroscopy/bioformats/pull/3202

Without this PR and using BF 6:
- Open a multi channel OMERO pyramid and zoom to view the highest resolution
- At the highest resolution the channels will appear duplicated
- This can be compared with the lower resolutions which should be unaffected

With the PR:
- The pyramids should behave and display as expected

