### PR TITLE
Bye bye commons-io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ repositories {
     jcenter()
 }
 
+configurations.all {
+    exclude group: 'commons-io'
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -23,7 +27,6 @@ dependencies {
     api("org.openmicroscopy:omero-common:5.5.0")
 
     // Keep from being exposed to child projects
-    implementation("commons-io:commons-io:2.6")
     implementation("commons-lang:commons-lang:2.6")
 }
 

--- a/src/main/java/ome/io/bioformats/BfPyramidPixelBuffer.java
+++ b/src/main/java/ome/io/bioformats/BfPyramidPixelBuffer.java
@@ -14,6 +14,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
 import java.util.List;
 
 import loci.formats.FormatException;
@@ -37,7 +38,6 @@ import ome.xml.model.enums.DimensionOrder;
 import ome.xml.model.enums.EnumerationException;
 import ome.xml.model.primitives.PositiveInteger;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -440,7 +440,7 @@ public class BfPyramidPixelBuffer implements PixelBuffer {
             try {
                 if (writerFile != null) {
                     try {
-                        FileUtils.moveFile(writerFile, readerFile);
+                        Files.move(writerFile.toPath(), readerFile.toPath());
                     } finally {
                         writerFile = null;
                     }

--- a/src/main/java/ome/io/nio/AbstractFileSystemService.java
+++ b/src/main/java/ome/io/nio/AbstractFileSystemService.java
@@ -6,9 +6,9 @@
 package ome.io.nio;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Formatter;
 
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +79,7 @@ public class AbstractFileSystemService {
      * @return the path relative to the root
      */
     public String getPixelsDirectory() {
-        return FilenameUtils.concat(root, PIXELS_PATH);
+        return Paths.get(root, PIXELS_PATH).toString();
     }
 
     /**
@@ -138,6 +138,6 @@ public class AbstractFileSystemService {
                 }
             }
         }
-        return FilenameUtils.concat(root, prefix + suffix + id);
+        return Paths.get(root, prefix + suffix + id).toString();
     }
 }

--- a/src/main/java/ome/io/nio/PixelsService.java
+++ b/src/main/java/ome/io/nio/PixelsService.java
@@ -40,13 +40,14 @@ import ome.model.core.Pixels;
 import ome.model.stats.StatsInfo;
 import ome.util.PixelData;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.FatalBeanException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
+
+import com.google.common.io.Files;
 
 /**
  * @author <br>
@@ -482,7 +483,7 @@ public class PixelsService extends AbstractFileSystemService
                     try
                     {
                         pixelsPyramidFile.delete();
-                        FileUtils.touch(pixelsPyramidFile); // ticket:5189
+                        Files.touch(pixelsPyramidFile); // ticket:5189
                     }
                     catch (Exception e2)
                     {

--- a/src/test/java/ome/io/nio/utests/AbstractPyramidPixelBufferUnitTest.java
+++ b/src/test/java/ome/io/nio/utests/AbstractPyramidPixelBufferUnitTest.java
@@ -6,9 +6,9 @@
  */
 package ome.io.nio.utests;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Paths;
 import java.util.List;
 
 import loci.formats.FormatTools;
@@ -24,7 +24,7 @@ import ome.util.checksum.ChecksumProviderFactory;
 import ome.util.checksum.ChecksumProviderFactoryImpl;
 import ome.util.checksum.ChecksumType;
 
-import org.apache.commons.io.FileUtils;
+import com.google.common.io.MoreFiles;
 
 /**
  * Tests the logic for creating {@link BfPyramidPixelBuffer} instances.
@@ -83,7 +83,7 @@ public abstract class AbstractPyramidPixelBufferUnitTest {
     }
 
     protected void deleteRoot() throws IOException {
-        FileUtils.deleteDirectory(new File(root));
+        MoreFiles.deleteRecursively(Paths.get(root));
     }
 
     protected short writeTiles(final List<String> hashDigests) throws FailedTileLoopException {

--- a/src/test/java/ome/io/nio/utests/BfPixelBufferUnitTest.java
+++ b/src/test/java/ome/io/nio/utests/BfPixelBufferUnitTest.java
@@ -5,8 +5,8 @@
 package ome.io.nio.utests;
 
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import ome.io.nio.PixelBuffer;
 import ome.io.nio.PixelsService;
@@ -14,11 +14,12 @@ import ome.io.nio.RomioPixelBuffer;
 import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
 
-import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import com.google.common.io.MoreFiles;
 
 /**
  * Tests the logic for creating {@link BfPixelBuffer} instances.
@@ -64,7 +65,7 @@ public class BfPixelBufferUnitTest {
 
     @AfterClass
     public void tearDown() throws IOException {
-        FileUtils.deleteDirectory(new File(root));
+        MoreFiles.deleteRecursively(Paths.get(root));
     }
 
     @Test

--- a/src/test/java/ome/io/nio/utests/HelperUnitTest.java
+++ b/src/test/java/ome/io/nio/utests/HelperUnitTest.java
@@ -6,11 +6,14 @@ package ome.io.nio.utests;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
-import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
+
+import com.google.common.io.MoreFiles;
+
 import ome.io.nio.PixelsService;
 
 public class HelperUnitTest {
@@ -28,7 +31,7 @@ public class HelperUnitTest {
 
     @AfterClass
     public void tearDown() throws IOException {
-        FileUtils.deleteDirectory(new File(ROOT));
+        MoreFiles.deleteRecursively(Paths.get(ROOT));
     }
 
     //

--- a/src/test/java/ome/io/nio/utests/HugePixelBufferUnitTest.java
+++ b/src/test/java/ome/io/nio/utests/HugePixelBufferUnitTest.java
@@ -4,15 +4,15 @@
  */
 package ome.io.nio.utests;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
-
-import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.io.MoreFiles;
 
 import ome.io.nio.DimensionsOutOfBoundsException;
 import ome.io.nio.PixelBuffer;
@@ -36,7 +36,7 @@ public class HugePixelBufferUnitTest {
 
     @AfterClass
     public void tearDown() throws IOException {
-        FileUtils.deleteDirectory(new File(ROOT));
+        MoreFiles.deleteRecursively(Paths.get(ROOT));
     }
 
     @BeforeMethod

--- a/src/test/java/ome/io/nio/utests/LargePixelBufferUnitTest.java
+++ b/src/test/java/ome/io/nio/utests/LargePixelBufferUnitTest.java
@@ -5,14 +5,15 @@
 package ome.io.nio.utests;
 
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
-import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.io.MoreFiles;
 
 import ome.io.nio.DimensionsOutOfBoundsException;
 import ome.io.nio.PixelBuffer;
@@ -36,7 +37,7 @@ public class LargePixelBufferUnitTest {
 
     @AfterClass
     public void tearDown() throws IOException {
-        FileUtils.deleteDirectory(new File(ROOT));
+        MoreFiles.deleteRecursively(Paths.get(ROOT));
     }
 
     @BeforeMethod

--- a/src/test/java/ome/io/nio/utests/NormalPixelBufferUnitTest.java
+++ b/src/test/java/ome/io/nio/utests/NormalPixelBufferUnitTest.java
@@ -5,14 +5,15 @@
 package ome.io.nio.utests;
 
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
-import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.io.MoreFiles;
 
 import ome.io.nio.DimensionsOutOfBoundsException;
 import ome.io.nio.PixelBuffer;
@@ -36,7 +37,7 @@ public class NormalPixelBufferUnitTest {
 
     @AfterClass
     public void tearDown() throws IOException {
-        FileUtils.deleteDirectory(new File(ROOT));
+        MoreFiles.deleteRecursively(Paths.get(ROOT));
     }
 
     @BeforeMethod

--- a/src/test/java/ome/io/nio/utests/OutOfBoundsUnitTest.java
+++ b/src/test/java/ome/io/nio/utests/OutOfBoundsUnitTest.java
@@ -5,8 +5,8 @@
 package ome.io.nio.utests;
 
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import ome.io.nio.DimensionsOutOfBoundsException;
 import ome.io.nio.PixelBuffer;
@@ -14,11 +14,12 @@ import ome.io.nio.PixelsService;
 import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
 
-import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.io.MoreFiles;
 
 /**
  * @author callan
@@ -34,7 +35,7 @@ public class OutOfBoundsUnitTest {
 
     @AfterClass
     public void tearDown() throws IOException {
-        FileUtils.deleteDirectory(new File(ROOT));
+        MoreFiles.deleteRecursively(Paths.get(ROOT));
     }
 
     @BeforeMethod

--- a/src/test/java/ome/io/nio/utests/PixelServiceCreatesDirectoryUnitTest.java
+++ b/src/test/java/ome/io/nio/utests/PixelServiceCreatesDirectoryUnitTest.java
@@ -6,19 +6,20 @@ package ome.io.nio.utests;
 
 
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import ome.io.nio.PixelBuffer;
 import ome.io.nio.PixelsService;
 import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
 
-import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.io.MoreFiles;
 
 public class PixelServiceCreatesDirectoryUnitTest {
     private Pixels pixels;
@@ -30,7 +31,7 @@ public class PixelServiceCreatesDirectoryUnitTest {
 
     @AfterClass
     public void tearDown() throws IOException {
-        FileUtils.deleteDirectory(new File(ROOT));
+        MoreFiles.deleteRecursively(Paths.get(ROOT));
     }
 
     @BeforeMethod


### PR DESCRIPTION
Remove use of commons-io. Most critical code paths were able to be replaced with Java 8 nio `Paths` or `Files` usage. Where that was not possible equivalent Guava functions were used.

@mtbc @rgozim @jburel @sbesson @joshmoore 