### PR TITLE
Improve message formatting for exception.

### DIFF
--- a/src/main/java/ome/io/nio/AbstractFileSystemService.java
+++ b/src/main/java/ome/io/nio/AbstractFileSystemService.java
@@ -43,7 +43,7 @@ public class AbstractFileSystemService {
         if (!rootDirectory.isDirectory() || !rootDirectory.canRead()
                 || !(isReadOnlyRepo || rootDirectory.canWrite())) {
             throw new IllegalArgumentException(
-                    "Invalid directory specified for file system service."
+                    "Invalid directory specified for file system service: "
 		    + rootDirectory);
         }
 


### PR DESCRIPTION
In https://github.com/ome/openmicroscopy/issues/6110#issuecomment-548766433 I noticed,
```
java.lang.IllegalArgumentException: Invalid directory specified for file system service./nfs/omero/idr-repo/omero-server
```
See the diff for an obvious formatting fix. Try setting `omero.data.dir` to nonsense to reproduce.