### PR TITLE
Allow sub-classes, etc. to call getPath()

### DIFF
--- a/src/main/java/ome/io/nio/AbstractFileSystemService.java
+++ b/src/main/java/ome/io/nio/AbstractFileSystemService.java
@@ -125,7 +125,7 @@ public class AbstractFileSystemService {
      * "ROOT/<prefix>/Dir-123/Dir-456/123456".
      *
      * @param prefix id type prefix
-     * @param id     the thumbnail identifier
+     * @param id     the model object identifier
      * @return       the path relative to the root
      */
     protected String getPath(String prefix, Long id) {

--- a/src/main/java/ome/io/nio/AbstractFileSystemService.java
+++ b/src/main/java/ome/io/nio/AbstractFileSystemService.java
@@ -122,7 +122,7 @@ public class AbstractFileSystemService {
      * Returns a numbered path relative to the root of this service for a
      * given prefix, but is ignorant of FS and similar constructs. For
      * example, given an id of 123456 this will return
-     * "ROOT/<path>/Dir-123/Dir-456/123456".
+     * "ROOT/<prefix>/Dir-123/Dir-456/123456".
      *
      * @param prefix id type prefix
      * @param id     the thumbnail identifier

--- a/src/main/java/ome/io/nio/AbstractFileSystemService.java
+++ b/src/main/java/ome/io/nio/AbstractFileSystemService.java
@@ -118,7 +118,17 @@ public class AbstractFileSystemService {
         return getPath(THUMBNAILS_PATH, id);
     }
 
-    private String getPath(String prefix, Long id) {
+    /**
+     * Returns a numbered path relative to the root of this service for a
+     * given prefix, but is ignorant of FS and similar constructs. For
+     * example, given an id of 123456 this will return
+     * "ROOT/<path>/Dir-123/Dir-456/123456".
+     *
+     * @param prefix id type prefix
+     * @param id     the thumbnail identifier
+     * @return       the path relative to the root
+     */
+    protected String getPath(String prefix, Long id) {
         String suffix = "";
         Long remaining = id;
         Long dirno = 0L;


### PR DESCRIPTION
We have a few use cases where we have sub-classes of `PixelsService` (and by extension `AbstractFileSystemService`) where utilizing the `getPath()` functionality would be very useful.