### PR TITLE
Improve performance of BfPixelBuffer.getResolutionDescriptions()

### DIFF
--- a/src/main/java/ome/io/bioformats/BfPixelBuffer.java
+++ b/src/main/java/ome/io/bioformats/BfPixelBuffer.java
@@ -568,17 +568,28 @@ public class BfPixelBuffer implements PixelBuffer, Serializable {
                              bfReader.getOptimalTileHeight());
     }
 
+    /* @see ome.io.nio.PixelBuffer#getResolutionDescriptions() */
     public List<List<Integer>> getResolutionDescriptions()
     {
         final List<List<Integer>> rv = new ArrayList<List<Integer>>();
-        final int no = bfReader.getResolutionCount();
-        final List<CoreMetadata> cms = bfReader.getCoreMetadataList();
-        for (int i = 0; i < no; i++)
+        final int no = getResolutionLevels();
+        // no need to retrieve all CoreMetadata objects
+        // if there is only one resolution
+        // this can be faster for plates
+        if (no == 1)
         {
-            int coreIndex = bfReader.seriesToCoreIndex(bfReader.getSeries()) + i;
-            CoreMetadata cm = cms.get(coreIndex);
-            List<Integer> sizes = Arrays.asList(cm.sizeX, cm.sizeY);
-            rv.add(sizes);
+            rv.add(Arrays.asList(bfReader.getSizeX(), bfReader.getSizeY()));
+        }
+        else
+        {
+            final List<CoreMetadata> cms = bfReader.getCoreMetadataList();
+            int coreIndex = bfReader.getCoreIndex();
+            for (int i = 0 i < no; i++)
+            {
+                CoreMetadata cm = cms.get(coreIndex + i);
+                List<Integer> sizes = Arrays.asList(cm.sizeX, cm.sizeY);
+                rv.add(sizes);
+            }
         }
         return rv;
     }

--- a/src/main/java/ome/io/bioformats/BfPixelBuffer.java
+++ b/src/main/java/ome/io/bioformats/BfPixelBuffer.java
@@ -20,6 +20,7 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
+import loci.formats.ReaderWrapper;
 import ome.conditions.ResourceError;
 import ome.io.nio.DimensionsOutOfBoundsException;
 import ome.io.nio.PixelBuffer;
@@ -582,9 +583,23 @@ public class BfPixelBuffer implements PixelBuffer, Serializable {
         }
         else
         {
-            final List<CoreMetadata> cms = bfReader.getCoreMetadataList();
+            // reader wrappers clone CoreMetadata objects
+            // during calls to getCoreMetadataList
+            // unwrap() prevents cloning, and should be safe since
+            // wrappers do not alter resolutions or XY dimensions
+            List<CoreMetadata> cms = null;
+            if (bfReader instanceof ReaderWrapper) {
+                try {
+                    cms = ((ReaderWrapper) bfReader).unwrap().getCoreMetadataList();
+                } catch (FormatException | IOException e) {
+                    log.trace("Could not unwrap bfReader", e);
+                }
+            }
+            if (cms == null) {
+                cms = bfReader.getCoreMetadataList();
+            }
             int coreIndex = bfReader.getCoreIndex();
-            for (int i = 0 i < no; i++)
+            for (int i = 0; i < no; i++)
             {
                 CoreMetadata cm = cms.get(coreIndex + i);
                 List<Integer> sizes = Arrays.asList(cm.sizeX, cm.sizeY);


### PR DESCRIPTION
Ported from a long-standing but never merged private PR. This is meant to address the underlying performance issues that https://github.com/glencoesoftware/omero-ms-image-region/pull/20 works around.

dcc1e17 adds a special case for single-resolution data to reduce the number of calls to `getCoreMetadataList()`. d63494a alters how `getCoreMetadataList()` is called, to bypass the cloning logic in https://github.com/ome/bioformats/blob/develop/components/formats-api/src/loci/formats/ReaderWrapper.java#L500

This was originally tested with https://downloads.openmicroscopy.org/images/PerkinElmer-Columbus/idr0020/. The time to call ```getResolutionDescriptions()``` once without this PR was ~1800ms; with this PR was <1ms.

Feel free to close if this breaks things or just isn't useful.