### PR TITLE
Requires pyramid float configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ java {
 dependencies {
     testImplementation("org.testng:testng:6.14.2")
 
-    api("org.openmicroscopy:omero-common:5.5.9")
+    api("org.openmicroscopy:omero-common:5.5.10-SNAPSHOT")
 
     // Keep from being exposed to child projects
     implementation("commons-io:commons-io:2.6")

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ java {
 dependencies {
     testImplementation("org.testng:testng:6.14.2")
 
-    api("org.openmicroscopy:omero-common:5.5.10-SNAPSHOT")
+    api("org.openmicroscopy:omero-common:5.5.9")
 
     // Keep from being exposed to child projects
     implementation("commons-io:commons-io:2.6")

--- a/src/main/java/ome/io/nio/ConfiguredTileSizes.java
+++ b/src/main/java/ome/io/nio/ConfiguredTileSizes.java
@@ -17,19 +17,7 @@ package ome.io.nio;
 public class ConfiguredTileSizes implements TileSizes {
 
     private final int tileWidth, tileHeight, maxPlaneWidth, maxPlaneHeight;
-    private boolean maxPlaneFloatOverride = true;
-
-    public ConfiguredTileSizes() {
-        this(256, 256, 3192, 3192); // Default as in omero.properties
-    }
-
-    public ConfiguredTileSizes(int tileWidth, int tileHeight,
-            int maxPlaneWidth, int maxPlaneHeight) {
-        this.tileWidth = tileWidth;
-        this.tileHeight = tileHeight;
-        this.maxPlaneWidth = maxPlaneWidth;
-        this.maxPlaneHeight = maxPlaneHeight;
-    }
+    private final boolean maxPlaneFloatOverride;
 
     public ConfiguredTileSizes(int tileWidth, int tileHeight,
             int maxPlaneWidth, int maxPlaneHeight,
@@ -39,6 +27,16 @@ public class ConfiguredTileSizes implements TileSizes {
         this.maxPlaneWidth = maxPlaneWidth;
         this.maxPlaneHeight = maxPlaneHeight;
         this.maxPlaneFloatOverride = maxPlaneFloatOverride;
+    }
+
+    public ConfiguredTileSizes(int tileWidth, int tileHeight,
+            int maxPlaneWidth, int maxPlaneHeight) {
+        this(tileWidth, tileHeight,
+                maxPlaneWidth, maxPlaneHeight, true);
+    }
+
+    public ConfiguredTileSizes() {
+        this(256, 256, 3192, 3192); // Default as in omero.properties
     }
 
     public int getTileWidth() {

--- a/src/main/java/ome/io/nio/ConfiguredTileSizes.java
+++ b/src/main/java/ome/io/nio/ConfiguredTileSizes.java
@@ -17,6 +17,7 @@ package ome.io.nio;
 public class ConfiguredTileSizes implements TileSizes {
 
     private final int tileWidth, tileHeight, maxPlaneWidth, maxPlaneHeight;
+    private boolean maxPlaneFloatOverride = true;
 
     public ConfiguredTileSizes() {
         this(256, 256, 3192, 3192); // Default as in omero.properties
@@ -28,6 +29,16 @@ public class ConfiguredTileSizes implements TileSizes {
         this.tileHeight = tileHeight;
         this.maxPlaneWidth = maxPlaneWidth;
         this.maxPlaneHeight = maxPlaneHeight;
+    }
+
+    public ConfiguredTileSizes(int tileWidth, int tileHeight,
+            int maxPlaneWidth, int maxPlaneHeight,
+            boolean maxPlaneFloatOverride) {
+        this.tileWidth = tileWidth;
+        this.tileHeight = tileHeight;
+        this.maxPlaneWidth = maxPlaneWidth;
+        this.maxPlaneHeight = maxPlaneHeight;
+        this.maxPlaneFloatOverride = maxPlaneFloatOverride;
     }
 
     public int getTileWidth() {
@@ -43,6 +54,10 @@ public class ConfiguredTileSizes implements TileSizes {
     }
     public int getMaxPlaneHeight() {
         return maxPlaneHeight;
+    }
+
+    public boolean getMaxPlaneFloatOverride() {
+        return maxPlaneFloatOverride;
     }
 
     @Override

--- a/src/main/java/ome/io/nio/PixelsService.java
+++ b/src/main/java/ome/io/nio/PixelsService.java
@@ -299,6 +299,12 @@ public class PixelsService extends AbstractFileSystemService
      */
     public StatsInfo[] makePyramid(Pixels pixels)
     {
+        String type = pixels.getPixelsType().getValue();
+        if ("float".equals(type) || "double".equals(type)) {
+            log.debug("Pyramid creation disabled for floating point"
+                    + " pixel data");
+            return null;
+        }
         final String pixelsFilePath = getPixelsPath(pixels.getId());
         final File pixelsFile = new File(pixelsFilePath);
         final String pixelsPyramidFilePath = pixelsFilePath + PYRAMID_SUFFIX;
@@ -670,9 +676,11 @@ public class PixelsService extends AbstractFileSystemService
      *         otherwise
      */
     public boolean requiresPixelsPyramid(Pixels pixels) {
-        String type = pixels.getPixelsType().getValue();
-        if ("float".equals(type) || "double".equals(type))
-            return false;
+        if (sizes.getMaxPlaneFloatOverride()) {
+            String type = pixels.getPixelsType().getValue();
+            if ("float".equals(type) || "double".equals(type))
+                return false;
+        }
         final long sizeX = pixels.getSizeX();
         final long sizeY = pixels.getSizeY();
         final boolean requirePyramid = (sizeX * sizeY) > (sizes.getMaxPlaneWidth()*sizes.getMaxPlaneHeight());

--- a/src/main/java/ome/io/nio/TileSizes.java
+++ b/src/main/java/ome/io/nio/TileSizes.java
@@ -21,5 +21,5 @@ public interface TileSizes {
     int getTileHeight();
     int getMaxPlaneWidth();
     int getMaxPlaneHeight();
-
+    boolean getMaxPlaneFloatOverride();
 }


### PR DESCRIPTION
See https://github.com/ome/omero-model/pull/81
And https://github.com/ome/omero-common/pull/35
And https://github.com/ome/omero-server/pull/141
Fixes https://github.com/ome/omero-romio/issues/36
Add floating point override config value to ConfiguredTileSizes and use the value to alter whether floating point data types always return `false` in `requiresPixelsPyramid`